### PR TITLE
use lowercase gotest everywhere

### DIFF
--- a/minidom/minidom_test.go
+++ b/minidom/minidom_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	testutils "github.com/jpfielding/goTest/testutils"
+	testutils "github.com/jpfielding/gotest/testutils"
 )
 
 func TestSimple(t *testing.T) {


### PR DESCRIPTION
to avoid confusing go tool dep on case insensitive filesystems